### PR TITLE
Allow choice of React rendering method

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,17 @@ option | values | default
 `writeResp` | `true`: writes the body response automatically | `true`
 `babel` | the options for [babel/register](https://babeljs.io/docs/usage/require/) | `{only: options.views}`
 `cache` | `true`: cache all the view files | `process.env.NODE_ENV === 'production'`
+`internals` | `true`: include React internals in output | `false`
+
+### renderToString vs renderToStaticMarkup
+
+React provides two ways to render components server-side:  
+
+- [ReactDOMServer.renderToStaticMarkup](https://facebook.github.io/react/docs/top-level-api.html#reactdomserver.rendertostaticmarkup) strips out all the React internals, reducing the size of the output. Best for static sites.  
+
+- [ReactDOMServer.renderToString](https://facebook.github.io/react/docs/top-level-api.html#reactdomserver.rendertostring) maintains React internals, allowing for client-side React to process the rendered markup very speedily. Best for an initial server-side rendering of a client-side application.  
+
+By default, the `ReactDOMServer.renderToStaticMarkup` method will be used. It is possible to use `ReactDOMServer.renderToString` instead (and maintain the React internals) by setting the `internals` option to `true`, or by setting the third parameter of `this.render` to `true` on a case-by-case basis.
 
 ### `ctx.state`
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ koa-react-view
 [node-image]: https://img.shields.io/badge/node.js-%3E=_0.12-green.svg?style=flat-square
 [node-url]: http://nodejs.org/download/
 
-An Koa view engine which renders React components on server.
+A Koa view engine which renders React components on server.
 
 ## Installation
 

--- a/index.js
+++ b/index.js
@@ -60,14 +60,20 @@ module.exports = function (app, _options) {
     }
     if (!path.extname(filepath)) filepath += options.extname;
 
+    if (typeof _locals === 'boolean') {
+      internals = _locals;
+      _locals = {};
+    }
+    internals = internals !== undefined ? internals : options.internals;
+
+    var render = internals
+                    ? ReactDOMServer.renderToString
+                    : ReactDOMServer.renderToStaticMarkup;
+
     var locals = {};
     // merge koa state
     merge(locals, this.state || {});
     merge(locals, _locals);
-
-    var render = (options.internals || internals || (typeof(_locals) == "boolean" && _locals))
-                    ? ReactDOMServer.renderToString
-                    : ReactDOMServer.renderToStaticMarkup;
 
     var markup = options.doctype || '';
     try {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -30,6 +30,44 @@ describe('koa-react-view', function () {
       .expect('<!DOCTYPE html><div>home</div>', done);
     });
 
+    it('should support ReactDOMServer.renderToString with locals', function (done) {
+      var app = App();
+      app.use(function*() {
+        this.render('home', { }, true);
+      });
+
+      request(app.listen())
+      .get('/')
+      .expect(200)
+      .expect(/<!DOCTYPE html><div data-reactid="\.[a-z0-9]*" data-react-checksum="[0-9\-]*"><\/div>/i, done);
+    });
+
+    it('should support ReactDOMServer.renderToString without locals', function (done) {
+      var app = App();
+      app.use(function*() {
+        this.render('home', true);
+      });
+
+      request(app.listen())
+      .get('/')
+      .expect(200)
+      .expect(/<!DOCTYPE html><div data-reactid="\.[a-z0-9]*" data-react-checksum="[0-9\-]*"><\/div>/i, done);
+    });
+    
+    it('should support ReactDOMServer.renderToString using internals option', function (done) {
+      var app = App({
+        internals: true
+      });
+      app.use(function*() {
+        this.render('home');
+      });
+
+      request(app.listen())
+      .get('/')
+      .expect(200)
+      .expect(/<!DOCTYPE html><div data-reactid="\.[a-z0-9]*" data-react-checksum="[0-9\-]*"><\/div>/i, done);
+    });
+
     it('should support ctx.state', function (done) {
       var app = App();
       app.use(function*() {


### PR DESCRIPTION
Currently react-view strips all React internals from the output which is probably fine in most cases. However, keeping the internals in allows for client-side React to speedily attach itself to the DOM. This commit adds support for choosing between the two approaches, with the previous approach being maintained as the default for backwards compatibility.
