### PR TITLE
Bump react dependencies to v15.

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,8 +23,8 @@
   "dependencies": {
     "copy-to": "~2.0.1",
     "js-beautify": "~1.5.6",
-    "react": "~0.14.2",
-    "react-dom": "~0.14.2"
+    "react": "^15.0.1",
+    "react-dom": "^15.0.1"
   },
   "devDependencies": {
     "autod": "2",

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -40,7 +40,7 @@ describe('koa-react-view', function () {
       request(app.listen())
       .get('/')
       .expect(200)
-      .expect(/<!DOCTYPE html><div data-reactid="\.[a-z0-9]*" data-react-checksum="[0-9\-]*"><\/div>/i, done);
+      .expect(/<!DOCTYPE html><div data-reactroot="" data-reactid="[0-9\-]*" data-react-checksum="[0-9\-]*"><\/div>/i, done);
     });
 
     it('should support ReactDOMServer.renderToString without locals', function (done) {
@@ -52,7 +52,7 @@ describe('koa-react-view', function () {
       request(app.listen())
       .get('/')
       .expect(200)
-      .expect(/<!DOCTYPE html><div data-reactid="\.[a-z0-9]*" data-react-checksum="[0-9\-]*"><\/div>/i, done);
+      .expect(/<!DOCTYPE html><div data-reactroot="" data-reactid="[0-9\-]*" data-react-checksum="[0-9\-]*"><\/div>/i, done);
     });
 
     it('should support ReactDOMServer.renderToString using internals option', function (done) {
@@ -66,7 +66,7 @@ describe('koa-react-view', function () {
       request(app.listen())
       .get('/')
       .expect(200)
-      .expect(/<!DOCTYPE html><div data-reactid="\.[a-z0-9]*" data-react-checksum="[0-9\-]*"><\/div>/i, done);
+      .expect(/<!DOCTYPE html><div data-reactroot="" data-reactid="[0-9\-]*" data-react-checksum="[0-9\-]*"><\/div>/i, done);
     });
 
     it('should support ctx.state', function (done) {


### PR DESCRIPTION
I'm sure the react-id and checksum etc can be disabled in v15, but they seem to be coming through in the tests, so i've updated the tests accordingly.
